### PR TITLE
chore: remove stackblitz mention

### DIFF
--- a/examples/features/cobadged/README.md
+++ b/examples/features/cobadged/README.md
@@ -4,16 +4,6 @@ In this example we integrate Primer's Web SDK v2 headless with co-badged cards.
 
 It uses [Astro](https://astro.build) as the base tool, but feel free to build your website and server however you'd like.
 
-## Running on your browser
-
-[Click here to immediately launch it on your browser](https://stackblitz.com/github/primer-io/checkout-web/tree/main/examples/features/cobadged).
-
-Once it's open, make sure to:
-
-1. Create a new file `.env` and copy contents from `.env.example` into it
-2. Get an `API_KEY` from your Primer Dashboard and paste it there
-   - Example: `API_KEY=1234-foo-bar-4321`
-
 ## Running locally
 
 1. Install [Bun](https://bun.sh)


### PR DESCRIPTION
Remove the "Run in your browser" section as Stackblitz does not support our SDK for now.